### PR TITLE
Project-1中僵尸进程没有回收

### DIFF
--- a/proj-1/deet/src/inferior.rs
+++ b/proj-1/deet/src/inferior.rs
@@ -146,9 +146,10 @@ impl Inferior {
     }
 
     /// Kill the inferior(child process).
-    pub fn kill(&mut self) -> Result<(), std::io::Error> {
+    pub fn kill(&mut self) -> Result<Status, nix::Error> {
         println!("Killing running inferior (pid {})", self.pid());
-        self.child.kill()
+        self.child.kill().expect("inferior couldn't be killed");
+        self.wait(None)
     }
 
     /// Returns the pid of this inferior.


### PR DESCRIPTION
Interior::kill在kill掉子进程后似乎没有显式回收，暂停后会产生僵尸进程